### PR TITLE
fix: obtener portada de libro desde el CDN de Hamelyn

### DIFF
--- a/src/backend/Books/application/BookHamelynFinder.ts
+++ b/src/backend/Books/application/BookHamelynFinder.ts
@@ -7,6 +7,10 @@ import { CloudinaryService } from "@/backend/shared/application/CloudinaryServic
 
 export class BookHamelynFinder {
 
+    // Hamelyn's product API (v5) no longer returns the cover in its payload;
+    // covers are served from the Bunny CDN under products/{isbn}/1.webp.
+    private static readonly HAMELYN_CDN_BASE_URL = "https://image-hamelyn.b-cdn.net";
+
     constructor(private readonly cloudinaryService: CloudinaryService) {}
 
     async find(isbn: BookId): Promise<Book> {
@@ -14,7 +18,8 @@ export class BookHamelynFinder {
             console.log("Calling to hamelyn")
             const response = await axios.get(`https://serverless.hamelyn.com/api/v4/product/${isbn}`);
             const result = response.data.productResult ? response.data.productResult : response.data;
-            const imageUrl = await this.cloudinaryService.transformAndUploadAsset(result._id, result.image);
+            const coverUrl = `${BookHamelynFinder.HAMELYN_CDN_BASE_URL}/products/${result._id}/1.webp`;
+            const imageUrl = await this.cloudinaryService.transformAndUploadAsset(result._id, coverUrl);
             return BookFactory.create(result, imageUrl);
         } catch (error) {
             if (axios.isAxiosError(error)) {

--- a/src/backend/shared/application/CloudinaryService.ts
+++ b/src/backend/shared/application/CloudinaryService.ts
@@ -15,8 +15,13 @@ export class CloudinaryService {
 
     async transformAndUploadAsset(fileName: string, assetUrl: string | undefined) {
         if (!assetUrl || !assetUrl.length) return DEFAULT_COVER_IMAGE;
-        const base64 = await this.transformAssetToBase64FromUrl(assetUrl);
-        return await this.upload(fileName, base64);
+        try {
+            const base64 = await this.transformAssetToBase64FromUrl(assetUrl);
+            return await this.upload(fileName, base64);
+        } catch (error) {
+            console.error(`Could not fetch/transform asset from ${assetUrl}, using default cover:`, error);
+            return DEFAULT_COVER_IMAGE;
+        }
     }
 
     async upload(fileName: string, base64: string) {


### PR DESCRIPTION
## Problema

Al dar de alta un libro nuevo, **nunca se mostraba la portada**: siempre acababa mostrándose la imagen fallback de "Image not available".

**Causa raíz:** la API de producto de Hamelyn `https://serverless.hamelyn.com/api/v4/product/{isbn}` ahora hace `301` → `v5`, y axios sigue la redirección. La respuesta de v5 **ya no incluye el campo `image`**, así que `result.image` llegaba `undefined`, y `CloudinaryService` caía siempre al cover por defecto (`DEFAULT_COVER_IMAGE`).

Afectaba a todos los libros, no solo a uno.

## Solución

- **`BookHamelynFinder`**: en vez de leer `result.image` (ya inexistente en v5), construye la URL de la portada en el CDN de Hamelyn (Bunny):
  `https://image-hamelyn.b-cdn.net/products/{isbn}/1.webp`.
  El flujo posterior no cambia: la imagen se descarga y se resube a nuestro Cloudinary.
- **`CloudinaryService.transformAndUploadAsset`**: ahora es resiliente. Si la descarga/transformación de la imagen falla (p. ej. un libro sin portada en el CDN → 404), devuelve el cover por defecto en lugar de lanzar una `Cloudinaryxception` que —por herencia de `Exception`— rompía el alta completa del libro con un 400.

## Verificación

- La URL del CDN devuelve `200` con webp real para todos los ISBNs probados (descarga server-side sin token).
- `tsc --noEmit` pasa sin errores.
- Probado en local dando de alta un libro nuevo.

## Notas / seguimiento (fuera del alcance de esta PR)

- Los libros **ya guardados** con la portada fallback no se auto-corrigen; necesitarían rehacer el alta o un backfill.
- La misma migración v4→v5 dejó sin datos a `pages`, `publisher` y `format` (v5 solo devuelve `attributes.authors`), por lo que caen a sus defaults. Pendiente de decidir si se aborda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)