### PR TITLE
fix: resolver issues de severidad baja (#40–#46)

### DIFF
--- a/src/app/api/books/[isbn]/route.ts
+++ b/src/app/api/books/[isbn]/route.ts
@@ -1,12 +1,17 @@
-import { NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { bookFindOneController, bookPutController } from "@/backend/Books/infrastructure/dependencies";
 import { MongoClientFactory } from "@/backend/shared/infrastructure/MongoDbClient";
 
 export async function PUT(req: NextRequest, { params }: { params: { isbn: string } }) {
+    try {
         const body = await req.json();
         const { isbn } = params;
         await MongoClientFactory.createAndConnectClient();
-        return await bookPutController.run(isbn, body.newBook);       
+        return await bookPutController.run(isbn, body.newBook);
+    } catch (error: unknown) {
+        console.error(error);
+        return NextResponse.json({ message: "Invalid request body" }, { status: 400 });
+    }
 }
 
 export async function GET(req: NextRequest, { params }: { params: { isbn: string } }) {

--- a/src/app/book/[isbn]/page.tsx
+++ b/src/app/book/[isbn]/page.tsx
@@ -1,4 +1,5 @@
 import { getBookReadByIsbn } from "@/app/lib/reads";
+import { notFound } from "next/navigation";
 import { Button, Chip } from "@nextui-org/react";
 import BookPageUsersTabs from "@/app/components/Books/ReadsUserTabs";
 import BookDataTable from "@/app/components/Books/BookDataTable";
@@ -11,7 +12,17 @@ import ReadStatusModal from "@/app/components/Books/Modal/ReadStatusEditModal";
 
 
 const BookPage = async ({ params }: { params: { isbn: string } }) => {
-    const book = await getBookReadByIsbn(params.isbn, true);
+    let book;
+    try {
+        book = await getBookReadByIsbn(params.isbn, true);
+    } catch (error) {
+        console.error(`Failed to fetch book ${params.isbn}:`, error);
+        throw new Error("No se ha podido cargar el libro. Inténtalo de nuevo más tarde.");
+    }
+
+    if (!book) {
+        notFound();
+    }
 
     return (
         <div className="w-full min-h-screen h-auto px-3 py-1">

--- a/src/app/components/Books/Edit/Form.tsx
+++ b/src/app/components/Books/Edit/Form.tsx
@@ -34,8 +34,6 @@ const BookEditForm = ({ book }: { book: any }) => {
 
     const onSubmit: SubmitHandler<any> = async (data) => {
         try {
-            const pages = parseInt(data.pages, 10);
-            data.pages = isNaN(pages) ? 0 : pages;
             await updateBook(data._id, data);
             router.push("/");
         } catch (err: any) {
@@ -181,7 +179,12 @@ const BookEditForm = ({ book }: { book: any }) => {
                         defaultValue={book.pages}
                         className="w-full"
                         type="number"
-                        {...register("pages")}
+                        {...register("pages", {
+                            required: "El número de páginas es obligatorio",
+                            valueAsNumber: true,
+                            min: { value: 1, message: "Debe ser un número mayor que 0" },
+                            validate: (value) => !isNaN(value) || "Debe ser un número válido",
+                        })}
                     />
                     {errors.pages && (
                         <p className="text-red-500 text-sm mt-1">

--- a/src/app/components/Books/Edit/RatingForm.tsx
+++ b/src/app/components/Books/Edit/RatingForm.tsx
@@ -3,6 +3,7 @@ import { useUser } from '@auth0/nextjs-auth0/client';
 import { Button } from '@nextui-org/react';
 import React, { Dispatch, SetStateAction } from 'react';
 import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
 
 const RatingForm = ({ isbn, setOpen }: { isbn: string, setOpen: Dispatch<SetStateAction<boolean>> }) => {
     const { user, isLoading } = useUser();
@@ -12,12 +13,22 @@ const RatingForm = ({ isbn, setOpen }: { isbn: string, setOpen: Dispatch<SetStat
         formState: { errors }
     } = useForm();
 
-    if (!user && isLoading) return (<div className="w-full flex flex-row justify-center"><p>Loading</p></div>)
+    if (isLoading) return (<div className="w-full flex flex-row justify-center"><p>Loading</p></div>)
 
     const submitHandler = async (data: any) => {
         const userId = user?.sub;
-        await updateBookRating(isbn, Number(data.rating), userId);
-        setOpen(prev => !prev);
+        if (!userId) {
+            toast.error("Debes iniciar sesión para valorar el libro.");
+            return;
+        }
+        try {
+            await updateBookRating(isbn, Number(data.rating), userId);
+            toast.success("¡Gracias por tu valoración!");
+            setOpen(prev => !prev);
+        } catch (error) {
+            console.error(error);
+            toast.error("No se ha podido guardar la valoración. Inténtalo de nuevo.");
+        }
     };
 
     return (

--- a/src/app/components/Books/Modal/AddReadModal.tsx
+++ b/src/app/components/Books/Modal/AddReadModal.tsx
@@ -15,6 +15,13 @@ const AddReadModal = ({ open, book, categories, handleClose }: { book: any; open
             status: "",
             categories: "",
         },
+        validate: (values) => {
+            const errors: { status?: string } = {};
+            if (!values.status) {
+                errors.status = "Debes elegir un estado";
+            }
+            return errors;
+        },
         onSubmit: async (values) => {
             if (!user || !user.sub) throw new Error("Cannot get user");
             const formattedCategories = values.categories.split(",");
@@ -37,7 +44,7 @@ const AddReadModal = ({ open, book, categories, handleClose }: { book: any; open
     return (
         <Modal hideCloseButton isOpen={open === true && book} className="max-h-[95vh] pb-24 md:pb-0 z-[9999]">
             <ModalContent className="h-auto max-h-[95vh] lg:max-h-max overflow-auto">
-                {(onClose) => (
+                {() => (
                     <>
                         <form onSubmit={formik.handleSubmit} className="w-full">
                             <ModalHeader className="flex flex-col gap-1">{book.title}</ModalHeader>
@@ -51,6 +58,8 @@ const AddReadModal = ({ open, book, categories, handleClose }: { book: any; open
                                                 className="max-w-xs"
                                                 onChange={(e) => formik.setFieldValue("status", e.target.value)}
                                                 value={formik.values.status}
+                                                isInvalid={!!formik.errors.status && formik.submitCount > 0}
+                                                errorMessage={formik.submitCount > 0 ? formik.errors.status : undefined}
                                             >
                                                 {Object.values(BookReadsStatus).map((status: string) => (
                                                     <SelectItem key={status}>
@@ -81,7 +90,7 @@ const AddReadModal = ({ open, book, categories, handleClose }: { book: any; open
                                     Cerrar
                                 </Button>
                                 {!isRead() || isRead() && !isOwnRead() ? (
-                                    <Button color="primary" type="submit" onPress={onClose}>
+                                    <Button color="primary" type="submit">
                                         Guardar
                                     </Button>
                                 ) : null}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Button } from "@nextui-org/react";
+import { useEffect } from "react";
+
+const Error = ({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) => {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className="w-full min-h-screen flex flex-col justify-center items-center gap-4 px-3">
+            <i className="fa-solid fa-triangle-exclamation text-5xl text-danger"></i>
+            <h1 className="text-2xl font-bold text-center">Algo ha ido mal</h1>
+            <p className="text-sm text-center text-gray-500 max-w-md">
+                Ha ocurrido un error inesperado. Puedes reintentar la acción o volver al inicio.
+            </p>
+            <div className="flex flex-row gap-3">
+                <Button color="primary" onClick={() => reset()}>
+                    Reintentar
+                </Button>
+                <Button variant="bordered" onClick={() => (window.location.href = "/")}>
+                    Ir al inicio
+                </Button>
+            </div>
+        </div>
+    );
+};
+
+export default Error;

--- a/src/backend/Categories/domain/Category.ts
+++ b/src/backend/Categories/domain/Category.ts
@@ -35,14 +35,14 @@ export class Category {
     static fromPrimitives(plainData: {
         _id: string;
         name: string;
-        slug: CategorySlug;
+        slug: string;
         createdAt: Date;
         updatedAt: Date;
     }): Category {
         return new Category({
             _id: new CategoryId(plainData._id),
             name: plainData.name,
-            slug: new CategorySlug(plainData.name),
+            slug: plainData.slug ? new CategorySlug(plainData.slug) : new CategorySlug(plainData.name),
             createdAt: plainData.createdAt,
             updatedAt: plainData.updatedAt,
         });

--- a/src/backend/Categories/infrastructure/repository/ICategoryRepositoryImpl.ts
+++ b/src/backend/Categories/infrastructure/repository/ICategoryRepositoryImpl.ts
@@ -4,9 +4,12 @@ import { Nullable } from "@/backend/shared/domain/utils";
 import { Category } from "@/backend/Categories/domain/Category";
 import { CategoryModel } from "@/backend/shared/infrastructure/MongoDbClient";
 import { CategoryFactory } from "@/backend/Categories/domain/CategoryFactory";
+import { MongoCriteriaConverter } from "@/backend/shared/infrastructure/MongoCriteriaConverter";
 import { isValidObjectId } from "mongoose";
 
 export class ICategoryRepositoryImpl implements ICategoryRepository {
+
+    private readonly criteriaConverter = new MongoCriteriaConverter();
 
     async save(category: Category): Promise<void> {
         const categoryPrimitives = category.toPrimitives();
@@ -26,8 +29,12 @@ export class ICategoryRepositoryImpl implements ICategoryRepository {
     }
 
     async search(criteria: Criteria): Promise<Category[]> {
-        console.log(criteria);
-        throw new Error("Method not implemented.");
+        const query = this.criteriaConverter.convert(criteria);
+        const categories = await CategoryModel.find(query.filter)
+            .sort(query.sort)
+            .skip(query.skip)
+            .limit(query.limit);
+        return categories.map(category => CategoryFactory.create(category));
     }
 
 }

--- a/src/backend/Ratings/domain/RatingId.ts
+++ b/src/backend/Ratings/domain/RatingId.ts
@@ -6,16 +6,13 @@ export class RatingId extends ValueObject<string> {
     ratingId: string;
 
     constructor(_ratingId: string) {
-        console.log({hola: _ratingId})
         super(_ratingId);
         this.ensureRatingIdIsValidObjectId(_ratingId);
         this.ratingId = _ratingId;
     }
-    
+
     private ensureRatingIdIsValidObjectId = (userId: string) => {
         if (!isValidObjectId(userId)) {
-            console.log("ERROR!")
-            console.log(userId)
             throw new InvalidArgumentException(`Invalid Argument: RatingId is not a valid ObjectId ${userId}`);
         }
     }

--- a/src/backend/Ratings/infrastructure/database/Rating.schema.ts
+++ b/src/backend/Ratings/infrastructure/database/Rating.schema.ts
@@ -22,8 +22,11 @@ export const ratingSchema = new Schema({
             type: Date,
             required: true,
             default: () => new Date()
-        }    
+        }
 });
+
+ratingSchema.index({ isbn: 1 });
+ratingSchema.index({ isbn: 1, user: 1 }, { unique: true });
 
 export interface RatingProps extends Document {
     _id: string;

--- a/src/backend/Reads/infrastructure/database/Read.schema.ts
+++ b/src/backend/Reads/infrastructure/database/Read.schema.ts
@@ -25,8 +25,12 @@ export const readSchema = new Schema({
             type: Date,
             required: true,
             default: () => new Date()
-        }    
+        }
 });
+
+readSchema.index({ user: 1 });
+readSchema.index({ book: 1 });
+readSchema.index({ book: 1, user: 1 }, { unique: true });
 
 export interface ReadProps extends Document {
     user: Types.ObjectId;

--- a/src/backend/Users/infrastructure/database/User.schema.ts
+++ b/src/backend/Users/infrastructure/database/User.schema.ts
@@ -41,6 +41,9 @@ export const userSchema = new Schema({
     }
 });
 
+userSchema.index({ auth0Id: 1 }, { unique: true });
+userSchema.index({ email: 1 }, { unique: true });
+
 export interface UserProps extends Document {
     _id: string;
     name: string;

--- a/src/backend/shared/application/CloudinaryService.ts
+++ b/src/backend/shared/application/CloudinaryService.ts
@@ -13,13 +13,17 @@ export class CloudinaryService {
         })
     }
 
+    // Note: this is used during book creation. We intentionally fall back to the
+    // default cover so an upload failure does not block the whole "alta" flow, but
+    // the failure is logged loudly so it can be detected/retried instead of passing
+    // silently. "No source image" is a legitimate fallback and is not treated as an error.
     async transformAndUploadAsset(fileName: string, assetUrl: string | undefined) {
         if (!assetUrl || !assetUrl.length) return DEFAULT_COVER_IMAGE;
         try {
             const base64 = await this.transformAssetToBase64FromUrl(assetUrl);
             return await this.upload(fileName, base64);
         } catch (error) {
-            console.error(`Could not fetch/transform asset from ${assetUrl}, using default cover:`, error);
+            console.error(`[Cloudinary] Cover upload FAILED for "${fileName}" (source: ${assetUrl}). Falling back to default cover — needs retry:`, error);
             return DEFAULT_COVER_IMAGE;
         }
     }
@@ -35,8 +39,10 @@ export class CloudinaryService {
 
             return uploadResult.secure_url;
         } catch (error) {
-            console.error(error);
-            return DEFAULT_COVER_IMAGE;
+            // Propagate: callers that upload an image on purpose (e.g. the portrait
+            // endpoint) must not receive a default cover as if the upload succeeded.
+            console.error(`[Cloudinary] Upload failed for "${fileName}":`, error);
+            throw new Cloudinaryxception(`Could not upload image "${fileName}" to Cloudinary`);
         }
     }
 


### PR DESCRIPTION
Resuelve las 7 issues con la label `low`, cada una en su propio commit lógico dentro de esta rama única.

## Cambios por issue

| Issue | Fix |
|-------|-----|
| #40 [API] PUT sin try/catch | `PUT /api/books/[isbn]` envuelve `req.json()` + conexión en try/catch → responde `400` ante body malformado en vez de un 500 con stack crudo. |
| #41 [Frontend] Falta error boundary | Añadido `app/error.tsx` (client component con estilo del proyecto). La página `book/[isbn]` captura el fallo del fetch y usa `notFound()` cuando el libro no existe. |
| #42 [Frontend] Huecos de validación | `AddReadModal`: `validate` de formik obliga a elegir `status` (+ feedback en el `Select`); el botón ya no cierra el modal si la validación falla. `Edit/Form`: `pages` validado como número > 0. `RatingForm`: guard corregido (`isLoading`) y feedback con toasts (sin sesión / error / éxito). |
| #43 [Cloudinary] Fallos en silencio | `upload()` propaga `Cloudinaryxception` en lugar de devolver la portada por defecto (la subida explícita de portada ya no simula éxito). `transformAndUploadAsset()` mantiene el fallback en el alta pero loggea el fallo de forma explícita para poder reintentarlo. |
| #44 [Limpieza] | Eliminados los `console.log` de depuración de `RatingId`. Implementado `ICategoryRepositoryImpl.search()` con el `MongoCriteriaConverter` existente. |
| #45 [Mongo] Índices y unicidad | `reads`: índices en `user`, `book` y único `{book,user}`. `ratings`: índice en `isbn` y único `{isbn,user}`. `users`: únicos en `auth0Id` y `email`. |
| #46 [Categories] fromPrimitives | `fromPrimitives` usa el `slug` persistido (con fallback al `name`), como hace `CategoryFactory.create`. |

## Verificación
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (solo warnings preexistentes ajenos a estos cambios)
- `npm run build` ✅

Closes #40, #41, #42, #43, #44, #45, #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)