### PR TITLE
fix(frontend): keys estables en GridBooks y avatares de CardBook (#36)

### DIFF
--- a/src/app/components/Books/CardBook.tsx
+++ b/src/app/components/Books/CardBook.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import Rating from "./Rating";
 
 const CardBook = ({ read }: { read: any }) => {
-    const usersImage = read.userReads.map((userRead: any) => userRead.user.picture);
+    const userReads = read.userReads ?? [];
     return (
         <Link href={`/book/${read.isbn}`} className="w-full">
             <Card className="col-span-12 sm:col-span-4 w-full aspect-[9/14] shadow-xl group overflow-hidden">
@@ -11,10 +11,16 @@ const CardBook = ({ read }: { read: any }) => {
                     <h4 className="text-white font-medium text-large line-clamp-3">{read.title}</h4>
                     <div className="w-full flex flex-row justify-between items-center">
                         {
-                            usersImage ? (
+                            userReads.length ? (
                                 <div>
                                     <AvatarGroup isBordered>
-                                        {usersImage.map((image: string) => (<Avatar src={image} key={image} className="w-6 h-6 text-tiny" />))}
+                                        {userReads.map((userRead: any, index: number) => (
+                                            <Avatar
+                                                src={userRead.user?.picture}
+                                                key={userRead.user?._id ?? userRead._id ?? index}
+                                                className="w-6 h-6 text-tiny"
+                                            />
+                                        ))}
                                     </AvatarGroup>
                                 </div>
                             ) : null

--- a/src/app/components/Books/GridBooks.tsx
+++ b/src/app/components/Books/GridBooks.tsx
@@ -45,7 +45,7 @@ const GridBooks = () => {
             {
                 reads && reads.length ? (
                     <div className="w-full grid grid-cols-2 xl:grid-cols-4 2xl:grid-cols-6 gap-2 md:gap-6 pb-12">
-                        {reads.map((read: any) => (<CardBook key={read._id} read={read} />))}
+                        {reads.map((read: any) => (<CardBook key={read.isbn} read={read} />))}
                     </div>
                 ) : null
             }


### PR DESCRIPTION
Cierra #36.

## Problema
- [`GridBooks.tsx`](src/app/components/Books/GridBooks.tsx) keaba las cards por `read._id`. La proyección de `ReadService.findAll` expone el identificador como **`isbn`** (el `_id` se pone a `0` a mitad del pipeline y solo lo "recupera" el `$group` final por casualidad), así que depender de `read._id` es frágil → warnings de React y reutilización incorrecta de nodos al filtrar/reordenar.
- [`CardBook.tsx`](src/app/components/Books/CardBook.tsx) keaba los `Avatar` por la **URL de la imagen**, que colisiona si dos usuarios comparten foto (o es `null`).

## Cambios
- `GridBooks`: `key={read.isbn}` (identificador estable y coherente con el `href` que ya usa `CardBook`).
- `CardBook`: itera `read.userReads` y kea cada `Avatar` por `user._id` (con fallback a `userRead._id` y al índice). De paso, el guard del bloque de avatares pasa a `userReads.length` (antes `usersImage` era siempre un array truthy aunque estuviera vacío).

## Verificación
- `npx tsc --noEmit` ✅
- `yarn lint` ✅ (sin nuevos warnings en estos ficheros)
- `yarn build` ✅

> Sin tests de componente: el setup de testing actual es backend puro (Node, sin jsdom/RTL). Los tests de frontend están fuera de alcance por decisión de #48 (se abordarán en una issue aparte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)