### PR TITLE
fix(frontend): un solo fetch con AbortController en GridBooks (#37)

### DIFF
--- a/src/app/components/Books/GridBooks.tsx
+++ b/src/app/components/Books/GridBooks.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 import CardBook from "./CardBook";
 import FilterWrapper from "./Filters/FilterWrapper";
 
-const fetchReads = async (params?: Record<string, any>) => {
+const fetchReads = async (params?: Record<string, any>, signal?: AbortSignal) => {
     const searchParams = new URLSearchParams();
     if (params) {
 
@@ -14,7 +14,7 @@ const fetchReads = async (params?: Record<string, any>) => {
         }
     }
 
-    const res = await fetch(`/api/reads${searchParams.size ? `?${searchParams.toString()}` : ""}`);
+    const res = await fetch(`/api/reads${searchParams.size ? `?${searchParams.toString()}` : ""}`, { signal });
     const response = await res.json();
     return response.reads;
 }
@@ -24,19 +24,27 @@ const GridBooks = () => {
     const [filters, setFilters] = useState<Record<string, any>>({});
 
     useEffect(() => {
-        const fetch = async () => {
-            const reads = await fetchReads();
-            setReads(reads);
-        }
-        fetch();
-    }, []);
+        // Single source of truth for loading reads. `filters` starts as `{}`, so this
+        // effect already covers the initial mount — no separate `[]` effect needed
+        // (that duplicated the request and raced on slow networks). The AbortController
+        // cancels the in-flight request when `filters` changes or the component unmounts,
+        // so a stale response can never overwrite a fresher one.
+        const controller = new AbortController();
 
-    useEffect(() => {
-        const fetch = async () => {
-            const reads = await fetchReads(filters);
-            setReads(reads);
-        }
-        fetch();
+        const load = async () => {
+            try {
+                const reads = await fetchReads(filters, controller.signal);
+                setReads(reads);
+            } catch (error) {
+                if (!controller.signal.aborted) {
+                    console.error(error);
+                }
+            }
+        };
+
+        load();
+
+        return () => controller.abort();
     }, [filters]);
 
     return (


### PR DESCRIPTION
Cierra #37.

## Problema
[`GridBooks.tsx`](src/app/components/Books/GridBooks.tsx) tenía **dos** `useEffect` (uno con `[]` y otro con `[filters]`, que arranca en `{}`) que disparaban la misma petición a `/api/reads` en el mount, sin cancelación → doble carga innecesaria y **race**: en redes lentas la respuesta que llegaba última sobrescribía datos más frescos.

## Cambios
- **Un único efecto** con dependencia `[filters]`. Como `filters` arranca en `{}`, ya cubre la carga inicial; se elimina el efecto `[]` duplicado.
- **`AbortController`**: cancela la petición en vuelo cuando cambian los filtros o se desmonta el componente, de modo que una respuesta obsoleta nunca puede pisar una más reciente. (De paso arregla también el doble disparo de React StrictMode en dev.)
- `fetchReads` acepta un `AbortSignal` y lo pasa a `fetch`; los errores de abort se ignoran, el resto se loguean.

## Verificación
- `npx tsc --noEmit` ✅
- `yarn lint` ✅
- `yarn build` ✅

> Sin tests de componente: el setup actual es backend puro (Node, sin jsdom/RTL); los tests de frontend quedaron fuera de alcance en #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)